### PR TITLE
Interface polish

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,6 @@ A generic library for tracing contour curves on a scalar 2D field.
 
 The idea with this library is to separate the contouring algorithm(s) from the various visualization tools, so that all tools can benefit from advances made here - as well as in other applications, independently of choice of visualization tool. The current implementation uses the [marching squares algorithm](http://en.wikipedia.org/wiki/Marching_squares) to calculate contours.
 
-There are [ongoing](https://github.com/tlycken/Contour.jl/issues/1) [api-discussions](https://github.com/tlycken/Contour.jl/issues/2), so the API of this library should not be considered stable yet. As a consequence, it is not yet published to METADATA, but can still be downloaded through `Pkg.clone("https://github.com/tlycken/Contour.jl.git")` if you want to kick the tires or help out. Hopefully, [this discussion on the users list](https://groups.google.com/forum/?fromgroups=#!topic/julia-dev/fqwnyOojRdg) concerning a generic package for geometric objects like points and lines will yield something useful, in which case this package will be adjusted to use those types.
-
 ## Usage Examples
 
 The Contour module currently expects input data to be on a Cartesian grid,
@@ -18,7 +16,6 @@ and supports both uniform and non-uniform grid spacings.  For the following
 examples, `x` and `y` are 1D sorted arrays that contain the grid coordinates,
 and `z` is a matrix arranged such that `z[xi,yi]` correspond to the location
 `(x[xi], y[yi])`.
-
 
 ```julia
 x = -3:0.01:3
@@ -39,36 +36,27 @@ an array of lines.  In the current example, we expect a single line that
 traces out a circle with radius 2:
 
 ```julia
-julia> c.level
+julia> level(c)
 4.0
 
-julia> c.lines
+julia> lines(c)
 1-element Array{Curve2{Float64},1}:
  Curve2{Float64}([[0.0,2.0],[0.0,2.0],[-1.73472e-18,2.0],[-0.01,1.99997],
  [-0.02,1.9999],[-0.03,1.99977],[-0.04,1.9996],[-0.05,1.99937],[-0.06,1.9991],
  [-0.07,1.99877]  …  [0.09,1.99796],[0.08,1.99839],[0.07,1.99877],[0.06,1.9991],
  [0.05,1.99937],[0.04,1.9996],[0.03,1.99977],[0.02,1.9999],[0.01,1.99997],
  [0.0,2.0]])
- ```
-
-The format of the output data is intented to give as extensive information as possible about the contour line, in a format that can be generalized in the future, if/when something like a [`Geometry.jl` package](https://groups.google.com/forum/#!topic/julia-dev/vZpZ8NBX_z8) is created. Each contour level is represented by an instance of
-
-```julia
-type ContourLevel{T}
-    level::T
-    lines::Vector{Curve2{T}}
-end
 ```
 
-where `Curve2` is in turn an abstraction over a curve in 2D (currently just a wrapper around a `Vector{Vector2}`, utilizing the `Vector2` type from [`ImmutableArrays.jl`](https://github.com/twadleigh/ImmutableArrays.jl) - this may change in the future).
+The format of the output data is intented to give as extensive information as possible about the contour line, in a format that can be generalized in the future, if/when something like a [`Geometry.jl` package](https://groups.google.com/forum/#!topic/julia-dev/vZpZ8NBX_z8) is created.
 
 However, it can admittedly be a little difficult to use this information in an application. For example, if we want to plot the contour line, it is much more practical to have the coordinates of the contour vertices as two lists instead of this complicated structure. No worries, just use `coordinates`:
 
 ```julia
-julia> xs, ys = coordinates(c.lines[1])
-([0.0,0.0,-1.73472e-18,-0.01,-0.02,-0.03,-0.04,-0.05,-0.06,-0.07  …  0.09,0.08,0.07,0.06,0.05,0.04,0.03,0.02,0.01,0.0],[2.0,2.0,2.0,1.99997,1.9999,1.99977,1.9996,1.99937,1.9991,1.99877  …  1.99796,1.99839,1.99877,1.9991,1.99937,1.9996,1.99977,1.9999,1.99997,2.0])
-
-julia> plot(xs, ys) # using your favorite plotting tool
+for l in lines(c) # each contour level can be represented by multiple lines
+    xs, ys = coordinates(l) # xs and ys are now Vectors of equal length
+    plot(xs, ys) # using your favorite plotting tool
+end
 ```
 
 `Contour.jl` makes sure that the coordinates are ordered correctly, and contours that close on themselves are given cyclically, so that e.g. `xs[1]==xs[end]` - in other words, plotting the contour does not require you to add the first point at the end manually to close the curve.

--- a/test/interface.jl
+++ b/test/interface.jl
@@ -12,6 +12,22 @@ function setup()
     xs, ys, zs
 end
 
+module Current
+
+using Contour, Base.Test, ..InterfaceTests
+
+xs, ys, zs = setup()
+
+cs = @inferred contours(xs,ys,zs)
+for c in levels(cs)
+    for l in lines(c)
+        x,y = coordinates(l)
+        @assert typeof(x) == typeof(y) == Vector{Float64}
+    end
+end
+
+end # Current
+
 module Legacy
 
 using Contour, Base.Test

--- a/test/interface.jl
+++ b/test/interface.jl
@@ -1,0 +1,39 @@
+module InterfaceTests
+
+export setup
+
+function setup()
+    nx, ny = 10, 10
+
+    xs = sort!(rand(nx))
+    ys = sort!(rand(ny))
+    zs = rand(nx,ny)
+
+    xs, ys, zs
+end
+
+module Legacy
+
+using Contour, Base.Test
+using ..InterfaceTests
+
+xs, ys, zs = setup()
+
+# v"0.0.7"
+cs = @inferred contours(xs, ys, zs)
+for c in cs
+    for l in c.lines
+        x,y = @inferred coordinates(l)
+        @assert typeof(x) == typeof(y) == Vector{Float64}
+    end
+end
+
+c2 = @inferred contour(xs, ys, zs, 0.3)
+for l in c2.lines
+    x,y = @inferred coordinates(l)
+    @assert typeof(x) == typeof(y) == Vector{Float64}
+end
+
+end # Legacy
+
+end # InterfaceTests

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,2 @@
-using Contour
-using Base.Test
-
 include("verify_vertices.jl")
+include("interface.jl")

--- a/test/verify_vertices.jl
+++ b/test/verify_vertices.jl
@@ -1,3 +1,5 @@
+using FixedSizeArrays, Contour, Base.Test
+
 # Setup test axes that will be shared among the tests
 
 # Shift the axes so that they do not line up with

--- a/test/verify_vertices.jl
+++ b/test/verify_vertices.jl
@@ -1,3 +1,5 @@
+module VerticesTests
+
 using FixedSizeArrays, Contour, Base.Test
 
 # Setup test axes that will be shared among the tests
@@ -159,3 +161,5 @@ contourlevels = Contour.contour(X,Y,Z,h)
 # Test contour location on a realistic dataset
 include("testdata.jl")
 Contour.contours(x,y,z)
+
+end


### PR DESCRIPTION
I came to think of a backwards-compatible way of implementing #29, so I went ahead and did it :)

The extra piece that makes this work is that the type that is now returned by `contours` is also an iterable, so iterating over it the way one previously iterated over the array we returned "just works". However, I'm inclined to immediately deprecate this API, so that with the next tagged release, we start moving people over to using `levels` and `lines` rather than property accessors and direct iteration. @darwindarak, does this sound reasonable?

There are now also some tests in `test/interface.jl` that verify that both the old and the new invocations work.