### PR TITLE
RFC: Update output and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,17 +40,10 @@ julia> level(c)
 4.0
 
 julia> lines(c)
-1-element Array{Curve2{Float64},1}:
- Curve2{Float64}([[0.0,2.0],[0.0,2.0],[-1.73472e-18,2.0],[-0.01,1.99997],
- [-0.02,1.9999],[-0.03,1.99977],[-0.04,1.9996],[-0.05,1.99937],[-0.06,1.9991],
- [-0.07,1.99877]  …  [0.09,1.99796],[0.08,1.99839],[0.07,1.99877],[0.06,1.9991],
- [0.05,1.99937],[0.04,1.9996],[0.03,1.99977],[0.02,1.9999],[0.01,1.99997],
- [0.0,2.0]])
+1 contour lines
 ```
 
-The format of the output data is intented to give as extensive information as possible about the contour line, in a format that can be generalized in the future, if/when something like a [`Geometry.jl` package](https://groups.google.com/forum/#!topic/julia-dev/vZpZ8NBX_z8) is created.
-
-However, it can admittedly be a little difficult to use this information in an application. For example, if we want to plot the contour line, it is much more practical to have the coordinates of the contour vertices as two lists instead of this complicated structure. No worries, just use `coordinates`:
+The format of the output data is intented to give as extensive information as possible about the contour line. However, it can admittedly be a little difficult to use this information in an application. For example, if we want to plot a contour level, it is much more practical to have the coordinates of the contour vertices as two lists instead of this complicated structure. No worries, just use `coordinates`:
 
 ```julia
 for l in lines(c) # each contour level can be represented by multiple lines
@@ -67,10 +60,7 @@ which returns an array of `ContourLevel` types.
 ```julia
 julia> h = [4.0, 5.0, 6.0];
 julia> c = contours(x, y, z, h)
-3-element Array{ContourLevel,1}:
- ContourLevel(4.0,[Curve2{Float64}([[0.0,2.0],…,[0.0,2.0]])])
- ContourLevel(5.0,[Curve2{Float64}([[0.28,-2.21846], …,[0.28,-2.21846]])])
- ContourLevel(6.0,[Curve2{Float64}([[-0.64,-2.36439],…,[-0.64,-2.36439]])])
+Collection of 3 levels.
 ```
 
 Instead of specifying all the levels explicitly, we can also
@@ -79,13 +69,10 @@ specify the number of levels we want.
 ```julia
 julia> N = 3;
 julia> c = contours(x, y, z, N)
-3-element Array{ContourLevel,1}:
- ContourLevel(8.5,[Curve2{Float64}([[0.62,2.84877],…,[0.62,2.84877]])])
- ContourLevel(17.0,[Curve2{Float64}([[3.0,2.82841],…,[3.0,-2.82841]])])
- ContourLevel(25.5,[Curve2{Float64}([[3.0,4.06201],…,[-3.0,4.06201]])])
+Collection of 3 levels
 ```
-Currently, `contours` will pick `N` levels that evenly spans the
-extrema of `z`.
+
+`contours` will pick `N` levels that evenly span the extrema of `z`.
 
 ## Credits
 The main authors of this package are [Darwin Darakananda](https://github.com/darwindarak/) and [Tomas Lycken](https://github.com/tlycken).

--- a/src/Contour.jl
+++ b/src/Contour.jl
@@ -10,8 +10,8 @@ type Curve2{T}
     vertices::Vector{Point{2,T}}
 end
 Curve2{T}(::Type{T}) = Curve2(Point{2, T}[])
-Base.writemime(io::IO, ::MIME"text/plain", c2::Curve2) = write(io, "$(typeof(c2)) with $(length(c2.vertices)-1) vertices")
-Base.writemime{TC<:Curve2}(io::IO, ::MIME"text/plain", c2s::Vector{TC}) = write(io, "$(length(c2s)) contour lines")
+Base.writemime(io::IO, ::MIME"text/plain", c2::Curve2) = write(io, "$(typeof(c2))\n  with $(length(c2.vertices)-1) vertices")
+Base.writemime{TC<:Curve2}(io::IO, ::MIME"text/plain", c2s::Vector{TC}) = write(io, "$(typeof(c2s))\n  $(length(c2s)) contour line(s)")
 
 type ContourLevel{T}
     level::T
@@ -19,7 +19,8 @@ type ContourLevel{T}
 end
 ContourLevel{T<:AbstractFloat}(h::T) = ContourLevel(h, Curve2{T}[])
 ContourLevel{T}(h::T) = ContourLevel(Float64(h))
-Base.writemime(io::IO, ::MIME"text/plain", cl::ContourLevel) = write(io, "ContourLevel at $(level(cl)) with $(length(lines(cl))) lines")
+Base.writemime(io::IO, ::MIME"text/plain", cl::ContourLevel) = write(io, "$(typeof(cl))\n  at $(level(cl)) with $(length(lines(cl))) line(s)")
+Base.writemime{CL<:ContourLevel}(io::IO, ::MIME"text/plain", cls::Vector{CL}) = write(io, "$(typeof(cls))\n  $(length(cls)) contour level(s)")
 lines(cl::ContourLevel) = cl.lines
 level(cl::ContourLevel) = cl.level
 
@@ -28,7 +29,7 @@ immutable ContourCollection{Tlevel<:ContourLevel}
 end
 ContourCollection() = ContourCollection(Float64)
 ContourCollection{Tlevel}(::Type{Tlevel}) = ContourCollection(ContourLevel{Tlevel}[])
-Base.writemime(io::IO, ::MIME"text/plain", cc::ContourCollection) = write(io, "Collection of $(length(levels(cc))) levels.")
+Base.writemime(io::IO, ::MIME"text/plain", cc::ContourCollection) = write(io, "$(typeof(cc))\n with $(length(levels(cc))) level(s).")
 
 levels(cc::ContourCollection) = cc.contours
 

--- a/src/Contour.jl
+++ b/src/Contour.jl
@@ -4,10 +4,14 @@ using Compat, FixedSizeArrays
 
 export ContourLevel, Curve2, contour, contours, level, levels, lines, coordinates
 
+import Base: push!, start, next, done, length, eltype
+
 type Curve2{T}
     vertices::Vector{Point{2,T}}
 end
 Curve2{T}(::Type{T}) = Curve2(Point{2, T}[])
+Base.writemime(io::IO, ::MIME"text/plain", c2::Curve2) = write(io, "$(typeof(c2)) with $(length(c2.vertices)-1) vertices")
+Base.writemime{TC<:Curve2}(io::IO, ::MIME"text/plain", c2s::Vector{TC}) = write(io, "$(length(c2s)) contour lines")
 
 type ContourLevel{T}
     level::T
@@ -15,7 +19,7 @@ type ContourLevel{T}
 end
 ContourLevel{T<:AbstractFloat}(h::T) = ContourLevel(h, Curve2{T}[])
 ContourLevel{T}(h::T) = ContourLevel(Float64(h))
-
+Base.writemime(io::IO, ::MIME"text/plain", cl::ContourLevel) = write(io, "ContourLevel at $(level(cl)) with $(length(lines(cl))) lines")
 lines(cl::ContourLevel) = cl.lines
 level(cl::ContourLevel) = cl.level
 
@@ -24,6 +28,7 @@ immutable ContourCollection{Tlevel<:ContourLevel}
 end
 ContourCollection() = ContourCollection(Float64)
 ContourCollection{Tlevel}(::Type{Tlevel}) = ContourCollection(ContourLevel{Tlevel}[])
+Base.writemime(io::IO, ::MIME"text/plain", cc::ContourCollection) = write(io, "Collection of $(length(levels(cc))) levels.")
 
 levels(cc::ContourCollection) = cc.contours
 


### PR DESCRIPTION
This builds on #30.

I updated the docs (to satisfy #28 too), and while I did that I noticed that it was really easy to end up with incomprehensible walls of text. Now, each documented function returns a single line of descriptive text instead, but maybe it's too little to be informative. What's a good middle ground here?