### PR TITLE
Deprecate iteration

### DIFF
--- a/src/Contour.jl
+++ b/src/Contour.jl
@@ -34,9 +34,12 @@ Base.writemime(io::IO, ::MIME"text/plain", cc::ContourCollection) = write(io, "$
 levels(cc::ContourCollection) = cc.contours
 
 push!{T}(cc::ContourCollection{T}, c::T) = (push!(cc.contours, c); c)
-@deprecate start(cc::ContourCollection) start(levels(cc))
-@deprecate next(cc::ContourCollection, state) next(levels(cc), state)
-@deprecate done(cc::ContourCollection, state) done(levels(cc), state)
+function start(cc::ContourCollection)
+    Base.depwarn("Iteration over ContourCollections is deprecated, use `levels(cc)` instead", :start)
+    start(levels(cc))
+end
+next(cc::ContourCollection, state) = next(levels(cc), state)
+done(cc::ContourCollection, state) = done(levels(cc), state)
 length(cc::ContourCollection) = length(cc.contours)
 eltype(cc::ContourCollection) = eltype(cc.contours)
 

--- a/src/Contour.jl
+++ b/src/Contour.jl
@@ -40,8 +40,8 @@ function start(cc::ContourCollection)
 end
 next(cc::ContourCollection, state) = next(levels(cc), state)
 done(cc::ContourCollection, state) = done(levels(cc), state)
-length(cc::ContourCollection) = length(cc.contours)
-eltype(cc::ContourCollection) = eltype(cc.contours)
+@deprecate length(cc::ContourCollection) length(levels(cc))
+@deprecate eltype(cc::ContourCollection) eltype(levels(cc))
 
 function contour(x, y, z, level::Number)
     # Todo: size checking on x,y,z

--- a/src/Contour.jl
+++ b/src/Contour.jl
@@ -33,12 +33,12 @@ Base.writemime(io::IO, ::MIME"text/plain", cc::ContourCollection) = write(io, "$
 
 levels(cc::ContourCollection) = cc.contours
 
-Base.push!{T}(cc::ContourCollection{T}, c::T) = (push!(cc.contours, c); c)
-Base.start(cc::ContourCollection) = start(cc.contours)
-Base.next(cc::ContourCollection, state) = next(cc.contours, state)
-Base.done(cc::ContourCollection, state) = done(cc.contours, state)
-Base.length(cc::ContourCollection) = length(cc.contours)
-Base.eltype(cc::ContourCollection) = eltype(cc.contours)
+push!{T}(cc::ContourCollection{T}, c::T) = (push!(cc.contours, c); c)
+@deprecate start(cc::ContourCollection) start(levels(cc))
+@deprecate next(cc::ContourCollection, state) next(levels(cc), state)
+@deprecate done(cc::ContourCollection, state) done(levels(cc), state)
+length(cc::ContourCollection) = length(cc.contours)
+eltype(cc::ContourCollection) = eltype(cc.contours)
 
 function contour(x, y, z, level::Number)
     # Todo: size checking on x,y,z

--- a/src/Contour.jl
+++ b/src/Contour.jl
@@ -33,7 +33,7 @@ Base.writemime(io::IO, ::MIME"text/plain", cc::ContourCollection) = write(io, "$
 
 levels(cc::ContourCollection) = cc.contours
 
-push!{T}(cc::ContourCollection{T}, c::T) = (push!(cc.contours, c); c)
+@deprecate push!{T}(cc::ContourCollection{T}, c::T) push!(levels(cc), c)
 function start(cc::ContourCollection)
     Base.depwarn("Iteration over ContourCollections is deprecated, use `levels(cc)` instead", :start)
     start(levels(cc))


### PR DESCRIPTION
Deprecated API:

```julia
for contour in contours(xs, ys, zs, N)
    for line in contour.lines
        x, y = coordinates(line)
        plot(x, y)
    end
end
```

New API:

```julia
cs = contours(xs, ys, zs, N)
for level in levels(cs)
    for line in lines(level)
        x, y = coordinates(line)
        plot(x, y)
    end
end
```

See #28 and #29 for some discussion.